### PR TITLE
Add HTTP/HTTPS agent option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
+### :zap: Added
+
+- Support for specifying option `http.Agent` or `https.Agent` when creating a new `Connection`
+
 ## [1.0.0] - 2017-07-16
 
 ### :zap: Added

--- a/src/shared/Connection.ts
+++ b/src/shared/Connection.ts
@@ -1,4 +1,16 @@
+import * as http from 'http';
+import * as https from 'https';
 import { Protocol } from './Protocol';
+
+/**
+ * Interface describing options for a connection.
+ */
+export interface Options {
+    /**
+     * The HTTP or HTTPS agent used when opening the connection.
+     */
+    agent?: http.Agent | https.Agent;
+}
 
 /**
  * Class describing a connection to a device.
@@ -24,7 +36,11 @@ export class Connection {
         /**
          * The password.
          */
-        public readonly password: string) {
+        public readonly password: string,
+        /**
+         * The options for the connection to the device.
+         */
+        public readonly options?: Options) {
     }
 
     /**

--- a/src/shared/Request.ts
+++ b/src/shared/Request.ts
@@ -15,6 +15,7 @@ export abstract class Request {
                 pass: this.connection.password,
                 sendImmediately: false,
             },
+            agent: this.connection.options?.agent,
         };
 
         try {

--- a/test/shared/Connection.spec.ts
+++ b/test/shared/Connection.spec.ts
@@ -1,8 +1,55 @@
+import * as http from 'http';
+import * as https from 'https';
 import { Connection, Protocol } from './../../src';
 
 describe('connection', () => {
 
     describe('#url', () => {
+
+        describe('#ctor(protocol, ...)', () => {
+
+            test('should return connection without options', () => {
+                // Act
+                const connection = new Connection(Protocol.Http, '1.2.3.4', 80, 'root', 'pass');
+
+                // Assert
+                expect(connection).toBeTruthy();
+            });
+
+            test('should return connection with http agent options', () => {
+                // Act
+                const connection = new Connection(
+                    Protocol.Http,
+                    '1.2.3.4',
+                    80,
+                    'root',
+                    'pass',
+                    {
+                        agent: new http.Agent()
+                    });
+
+                // Assert
+                expect(connection).toBeTruthy();
+                expect(connection.options?.agent).toBeTruthy();
+            });
+
+            test('should return connection with https agent options', () => {
+                // Act
+                const connection = new Connection(
+                    Protocol.Http,
+                    '1.2.3.4',
+                    80,
+                    'root',
+                    'pass',
+                    {
+                        agent: new https.Agent()
+                    });
+
+                // Assert
+                expect(connection).toBeTruthy();
+                expect(connection.options?.agent).toBeTruthy();
+            });
+        });
 
         test('should return URL given HTTP protocol', () => {
             // Act


### PR DESCRIPTION
Add options passed down to the HTTP/HTTPS module, lets start with `http.Agent` and `https.Agent`.